### PR TITLE
Proposal: refactor EasyMock to be a trait instead of using static methods

### DIFF
--- a/src/EasyMock.php
+++ b/src/EasyMock.php
@@ -2,7 +2,6 @@
 
 namespace EasyMock;
 
-use PHPUnit_Framework_MockObject_Generator;
 use PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount as AnyInvokedCount;
 use PHPUnit_Framework_MockObject_Matcher_Invocation as InvocationMatcher;
 use PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce as InvokedAtLeastOnce;
@@ -13,7 +12,7 @@ use PHPUnit_Framework_MockObject_MockObject as MockObject;
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class EasyMock
+trait EasyMock
 {
     /**
      * Mock the given class.
@@ -26,16 +25,16 @@ class EasyMock
      *
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
-    public static function mock($classname, array $methods = array())
+    protected function easyMock($classname, array $methods = array())
     {
         if ($classname instanceof MockObject) {
             $mock = $classname;
         } else {
-            $mock = self::createMock($classname);
+            $mock = $this->createMock($classname);
         }
 
         foreach ($methods as $method => $return) {
-            self::mockMethod($mock, $method, new AnyInvokedCount, $return);
+            $this->mockMethod($mock, $method, new AnyInvokedCount, $return);
         }
 
         return $mock;
@@ -47,29 +46,29 @@ class EasyMock
      * This is the same as EasyMock::mock() except this assert that methods are called at
      * least once.
      *
-     * @see mock()
+     * @see easyMock()
      *
      * @param string $classname The class to mock. Can also be an existing mock to mock new methods.
      * @param array  $methods   Array of values to return, indexed by the method name.
      *
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
-    public static function spy($classname, array $methods = array())
+    protected function easySpy($classname, array $methods = array())
     {
         if ($classname instanceof MockObject) {
             $mock = $classname;
         } else {
-            $mock = self::createMock($classname);
+            $mock = $this->createMock($classname);
         }
 
         foreach ($methods as $method => $return) {
-            self::mockMethod($mock, $method, new InvokedAtLeastOnce, $return);
+            $this->mockMethod($mock, $method, new InvokedAtLeastOnce, $return);
         }
 
         return $mock;
     }
 
-    private static function mockMethod(MockObject $mock, $method, InvocationMatcher $invocation, $return)
+    private function mockMethod(MockObject $mock, $method, InvocationMatcher $invocation, $return)
     {
         $methodAssertion = $mock->expects($invocation)
             ->method($method);
@@ -87,11 +86,9 @@ class EasyMock
      * @param string $classname
      * @return MockObject
      */
-    private static function createMock($classname)
+    private function createMock($classname)
     {
-        $mockGenerator = new PHPUnit_Framework_MockObject_Generator();
-
-        return $mockGenerator->getMock(
+        return $this->getMock(
             $classname,
             array(),
             array(),

--- a/tests/MockClassTest.php
+++ b/tests/MockClassTest.php
@@ -12,13 +12,15 @@ use EasyMock\Test\Fixture\InterfaceFixture;
  */
 class MockClassTest extends \PHPUnit_Framework_TestCase
 {
+    use EasyMock;
+
     /**
      * @test
      */
     public function should_mock_objects()
     {
         /** @var ClassFixture $mock */
-        $mock = EasyMock::mock('EasyMock\Test\Fixture\ClassFixture');
+        $mock = $this->easyMock('EasyMock\Test\Fixture\ClassFixture');
 
         $this->assertInstanceOf('PHPUnit_Framework_MockObject_MockObject', $mock);
         $this->assertNull($mock->foo());
@@ -30,7 +32,7 @@ class MockClassTest extends \PHPUnit_Framework_TestCase
     public function should_mock_interfaces()
     {
         /** @var InterfaceFixture $mock */
-        $mock = EasyMock::mock('EasyMock\Test\Fixture\InterfaceFixture');
+        $mock = $this->easyMock('EasyMock\Test\Fixture\InterfaceFixture');
 
         $this->assertInstanceOf('PHPUnit_Framework_MockObject_MockObject', $mock);
         $this->assertNull($mock->foo());
@@ -42,7 +44,7 @@ class MockClassTest extends \PHPUnit_Framework_TestCase
     public function not_mocked_methods_should_return_null()
     {
         /** @var ClassFixture $mock */
-        $mock = EasyMock::mock('EasyMock\Test\Fixture\ClassFixture');
+        $mock = $this->easyMock('EasyMock\Test\Fixture\ClassFixture');
 
         $this->assertNull($mock->foo());
     }
@@ -53,7 +55,7 @@ class MockClassTest extends \PHPUnit_Framework_TestCase
     public function should_mock_existing_method_with_a_value()
     {
         /** @var ClassFixture $mock */
-        $mock = EasyMock::mock('EasyMock\Test\Fixture\ClassFixture', array(
+        $mock = $this->easyMock('EasyMock\Test\Fixture\ClassFixture', array(
             'foo' => 'bar',
         ));
 
@@ -66,7 +68,7 @@ class MockClassTest extends \PHPUnit_Framework_TestCase
     public function should_mock_existing_method_with_a_callback()
     {
         /** @var ClassFixture $mock */
-        $mock = EasyMock::mock('EasyMock\Test\Fixture\ClassFixture', array(
+        $mock = $this->easyMock('EasyMock\Test\Fixture\ClassFixture', array(
             'foo' => function () {
                 return 'bar';
             },
@@ -83,7 +85,7 @@ class MockClassTest extends \PHPUnit_Framework_TestCase
     public function should_mock_existing_method_to_throw_exception()
     {
         /** @var ClassFixture $mock */
-        $mock = EasyMock::mock('EasyMock\Test\Fixture\ClassFixture', array(
+        $mock = $this->easyMock('EasyMock\Test\Fixture\ClassFixture', array(
             'foo' => new CustomException('My message'),
         ));
         $mock->foo();
@@ -95,8 +97,8 @@ class MockClassTest extends \PHPUnit_Framework_TestCase
     public function should_mock_new_methods_on_existing_mock()
     {
         /** @var ClassFixture $mock */
-        $mock = EasyMock::mock('EasyMock\Test\Fixture\ClassFixture');
-        $mock = EasyMock::mock($mock, array(
+        $mock = $this->easyMock('EasyMock\Test\Fixture\ClassFixture');
+        $mock = $this->easyMock($mock, array(
             'foo' => 'bar',
         ));
 
@@ -108,8 +110,10 @@ class MockClassTest extends \PHPUnit_Framework_TestCase
      */
     public function should_allow_to_spy_method_calls()
     {
-        $mock = EasyMock::spy('EasyMock\Test\Fixture\ClassFixture', array(
+        $mock = $this->easySpy('EasyMock\Test\Fixture\ClassFixture', array(
             'foo' => 'bar',
         ));
+
+        $this->assertEquals('bar', $mock->foo());
     }
 }


### PR DESCRIPTION
This is a proposed fix for #1.

It means a big change, but allows us to use PHPUnit's `getMock()` method for mock creation, which registers the created mocks to check their expectations, which is needed to check if a spy was actually called.

I chose not to extend `PHPUnit_Framework_TestCase` because with a trait you have the possilility to "patch" for example [`Silex\WebTestCase`](https://github.com/silexphp/Silex/blob/master/src%2FSilex%2FWebTestCase.php?ts=2).
## 

The spy test now fails like it should if we don't call the spy but I wasn't able to create a test with an expected exception becaue the exception is not thrown within the test but from PHPUnit itself and thus cannot be catched in the test (at least I don't know how).
