### PR TITLE
fix typo in test

### DIFF
--- a/tests/EasyMockTest.php
+++ b/tests/EasyMockTest.php
@@ -138,7 +138,7 @@ class EasyMockTest extends \PHPUnit_Framework_TestCase
             $mock->__phpunit_verify();
             $this->fail('Exception not thrown');
         } catch (\PHPUnit_Framework_ExpectationFailedException $e) {
-            $this->assertContains('Expected invocation at least once but it never occured', $e->getMessage());
+            $this->assertContains('Expected invocation at least once but it never occur', $e->getMessage());
         }
 
         // Invoke the mock: the test should now pass


### PR DESCRIPTION
Without this, using PHPUnit 5.4.4

```
There was 1 failure:

1) EasyMock\Test\EasyMockTest::should_allow_to_spy_method_calls
Failed asserting that 'Expectation failed for method name is equal to <string:foo> when invoked at least once.
Expected invocation at least once but it never occurred.
' contains "Expected invocation at least once but it never occured".

/tmp/phpunit-easymock/tests/EasyMockTest.php:141

```
