### PR TITLE
Allow PHPUnit 7.x and PHP 7.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea/
 /vendor/
 /composer.phar
 /composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   - phpenv config-rm xdebug.ini || echo "xdebug not available"
   - composer self-update
 
-install: travis_retry composer install --optimize-autoloader --prefer-dist --prefer-stable --no-progress --no-interaction --no-suggest $COMPOSER_FLAGS -vv
+install: travis_retry composer install --optimize-autoloader --prefer-dist --no-progress --no-interaction --no-suggest $COMPOSER_FLAGS -vv
 
 script: vendor/bin/phpunit --colors --columns 117 --no-coverage
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   - phpenv config-rm xdebug.ini || echo "xdebug not available"
   - composer self-update
 
-install: travis_retry composer install --optimize-autoloader --prefer-dist --no-progress --no-interaction --no-suggest $COMPOSER_FLAGS -vv
+install: travis_retry composer update --optimize-autoloader --prefer-dist --prefer-stable --no-progress --no-interaction --no-suggest $COMPOSER_FLAGS -vv
 
 script: vendor/bin/phpunit --colors --columns 117 --no-coverage
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,23 +10,40 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
   - nightly
 
-matrix:
-  fast_finish: true
-  allow_failures:
-    - php: nightly
-  include:
-    - php: 7.0
-      env: dependencies=lowest
+env:
+  - COMPOSER_FLAGS="--prefer-lowest"
+  - COMPOSER_FLAGS=""
+
+stages:
+  - test
+  - test with coverage
 
 cache:
   directories:
     - $HOME/.composer/cache
 
-before_script:
-  - composer install -n
-  - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest --prefer-stable -n; fi;
+before_install:
+  - phpenv config-rm xdebug.ini || echo "xdebug not available"
+  - composer self-update
 
-script:
-  - vendor/bin/phpunit
+install: travis_retry composer install --optimize-autoloader --prefer-dist --prefer-stable --no-progress --no-interaction --no-suggest $COMPOSER_FLAGS -vv
+
+script: vendor/bin/phpunit --colors --columns 117 --no-coverage
+
+jobs:
+  allow_failures:
+    - php: 7.3
+    - php: nightly
+  include:
+    - php: nightly
+      env: COMPOSER_FLAGS="--ignore-platform-reqs"
+
+    - stage: test with coverage
+      os: linux
+      php: 7.1
+      env: COMPOSER_FLAGS=""
+      before_install: composer self-update
+      script: vendor/bin/phpunit --colors --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require": {
         "php": "~7.0",
-        "phpunit/phpunit-mock-objects": "~4.0|~5.0|~6.0"
+        "phpunit/phpunit-mock-objects": "~5.0|~6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~6.4|~7.0"

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
     },
     "require": {
         "php": "~7.0",
-        "phpunit/phpunit-mock-objects": "~4.0"
+        "phpunit/phpunit-mock-objects": "~4.0|~5.0|~6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~6.4"
+        "phpunit/phpunit": "~6.4|~7.0"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,9 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         bootstrap="./vendor/autoload.php">
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+        backupGlobals="false"
+        backupStaticAttributes="false"
+        beStrictAboutChangesToGlobalState="true"
+        beStrictAboutCoversAnnotation="false"
+        beStrictAboutOutputDuringTests="true"
+        beStrictAboutTestsThatDoNotTestAnything="true"
+        beStrictAboutTodoAnnotatedTests="true"
+        failOnWarning="true"
+        failOnRisky="true"
+        verbose="false"
+        bootstrap="vendor/autoload.php"
+        enforceTimeLimit="false"
+        colors="true"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+    >
+    <php>
+        <ini name="error_reporting" value="-1"/>
+        <ini name="memory_limit" value="-1"/>
+        <ini name="date.timezone" value="UTC"/>
+    </php>
 
     <testsuites>
         <testsuite name="Test suite">

--- a/src/EasyMock.php
+++ b/src/EasyMock.php
@@ -34,7 +34,7 @@ trait EasyMock
         }
 
         foreach ($methods as $method => $return) {
-            $this->mockMethod($mock, $method, new AnyInvokedCount, $return);
+            $this->mockMethod($mock, $method, new AnyInvokedCount(), $return);
         }
 
         return $mock;

--- a/src/EasyMock.php
+++ b/src/EasyMock.php
@@ -2,10 +2,10 @@
 
 namespace EasyMock;
 
-use PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount as AnyInvokedCount;
-use PHPUnit_Framework_MockObject_Matcher_Invocation as InvocationMatcher;
-use PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce as InvokedAtLeastOnce;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\Matcher\AnyInvokedCount;
+use PHPUnit\Framework\MockObject\Matcher\Invocation as InvocationMatcher;
+use PHPUnit\Framework\MockObject\Matcher\InvokedAtLeastOnce;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Generates mock objects.
@@ -23,7 +23,7 @@ trait EasyMock
      * @param string $classname The class to mock. Can also be an existing mock to mock new methods.
      * @param array  $methods   Array of values to return, indexed by the method name.
      *
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return \PHPUnit\Framework\MockObject\MockObject
      */
     protected function easyMock($classname, array $methods = array())
     {
@@ -51,7 +51,7 @@ trait EasyMock
      * @param string $classname The class to mock. Can also be an existing mock to mock new methods.
      * @param array  $methods   Array of values to return, indexed by the method name.
      *
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return \PHPUnit\Framework\MockObject\MockObject
      */
     protected function easySpy($classname, array $methods = array())
     {

--- a/tests/EasyMockTest.php
+++ b/tests/EasyMockTest.php
@@ -25,7 +25,7 @@ class EasyMockTest extends TestCase
         /** @var ClassFixture $mock */
         $mock = $this->easyMock('EasyMock\Test\Fixture\ClassFixture');
 
-        $this->assertInstanceOf('PHPUnit_Framework_MockObject_MockObject', $mock);
+        $this->assertInstanceOf('PHPUnit\Framework\MockObject\MockObject', $mock);
         $this->assertNull($mock->foo());
     }
 
@@ -47,7 +47,7 @@ class EasyMockTest extends TestCase
         /** @var InterfaceFixture $mock */
         $mock = $this->easyMock('EasyMock\Test\Fixture\InterfaceFixture');
 
-        $this->assertInstanceOf('PHPUnit_Framework_MockObject_MockObject', $mock);
+        $this->assertInstanceOf('PHPUnit\Framework\MockObject\MockObject', $mock);
         $this->assertNull($mock->foo());
     }
 

--- a/tests/EasyMockTest.php
+++ b/tests/EasyMockTest.php
@@ -35,7 +35,7 @@ class EasyMockTest extends TestCase
     public function should_skip_the_constructor()
     {
         /** @var ClassWithConstructor $mock */
-        $mock = $this->easyMock('EasyMock\Test\Fixture\ClassWithConstructor');
+        $mock = $this->easyMock('\EasyMock\Test\Fixture\ClassWithConstructor');
         $this->assertFalse($mock->constructorCalled);
     }
 
@@ -128,7 +128,7 @@ class EasyMockTest extends TestCase
         ));
 
         // Test PHPUnit's internals to check that the spy was registered
-        $property = new \ReflectionProperty('PHPUnit\Framework\TestCase', 'mockObjects');
+        $property = new \ReflectionProperty('\PHPUnit\Framework\TestCase', 'mockObjects');
         $property->setAccessible(true);
         $mockObjects = $property->getValue($this);
 


### PR DESCRIPTION
This PR want the following:
- allow tests on PHP 7.3 on travis-ci (nightly is now 7.4-dev)
- allow tests with PHPUnit 7.x
- use the build stages on travis-ci to avoid `if` commands
- test against `--prefer-lowest` for every PHP version
- remove xdebug for builds without coverage to make them faster

This is nessesary to allow PHP 7.3 and PHPUnit 7.5 for PHP-DI