### PR TITLE
Allow PHPUnit 10 and 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,6 @@
     },
     "require": {
         "php": ">=7.3",
-        "phpunit/phpunit": "^8.5|^9.0"
+        "phpunit/phpunit": "^8.5|^9.0|^10.0|^11.0"
     }
 }


### PR DESCRIPTION
This package is preventing projects using it to run higher versions of PHPUnit.

This PR simply allows higher version of PHPUnit.

A quick merge and version stamp would be appreciated!  Thanks.